### PR TITLE
refactor(spotify): stop handling in go routine

### DIFF
--- a/internal/spotify/spotify.go
+++ b/internal/spotify/spotify.go
@@ -70,7 +70,7 @@ func (c *Client) Listen() {
 	for {
 		select {
 		case m := <-c.MusicChan:
-			go c.handle(m)
+			c.handle(m)
 		}
 	}
 }


### PR DESCRIPTION
Sometimes there are multiple posts containg the same track. When handled
in go routines, a track might be added multiple times. Simply stop doing
so to fix the issue. There are seldom many tracks in the pipe, so doing
so should cause much performance loss.